### PR TITLE
MOB-2351

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,22 +99,6 @@ componentDidMount(): void {
 }
 ```
 
-### Advanced iOS Initialization (Optional)
-For more control over SDK behavior, you can use the advanced initialization method with configuration options:
-
-```js
-await TSAccountProtectionSDKModule.initializeIOS(
-  clientId, 
-  baseUrl, // optional, can be null
-  {
-    enableTrackingBehavioralData: true,    // Track user behavior patterns (default: true)
-    enableLocationEvents: true,            // Track location events (default: true) 
-    enableTrackingNavigationData: true,    // Track app navigation patterns (default: true)
-    enableTrackingStaticData: true,        // Track device/app static info (default: true)
-  }
-);
-```
-
 ## Module API
 
 #### Set UserID after authentication

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Version 0.1.9
 
-### Breaking Changes
+### Breaking Changes (iOS only)
 - **Removed TSConfiguration interface**: Simplified SDK initialization by removing configuration options
 - **Updated initializeIOS method**: No longer accepts configuration parameters - now only requires `clientId` and optional `baseUrl`
 - **Removed tracking configuration options**: Eliminated `enableTrackingBehavioralData`, `enableLocationEvents`, `enableTrackingNavigationData`, and `enableTrackingStaticData` parameters

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Version 0.1.9
+
+### Breaking Changes
+- **Removed TSConfiguration interface**: Simplified SDK initialization by removing configuration options
+- **Updated initializeIOS method**: No longer accepts configuration parameters - now only requires `clientId` and optional `baseUrl`
+- **Removed tracking configuration options**: Eliminated `enableTrackingBehavioralData`, `enableLocationEvents`, `enableTrackingNavigationData`, and `enableTrackingStaticData` parameters
+
+### API Changes
+- **Simplified initialization**: `initializeIOS(clientId: string, baseUrl?: string)` - configuration parameter removed
+- **Backward compatibility**: Existing code using `initializeSDKIOS()` continues to work unchanged
+
 ## Version 0.1.8
 
 ### Enhanced Configuration Options

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -888,7 +888,7 @@ PODS:
   - React-Mapbuffer (0.73.5):
     - glog
     - React-debug
-  - react-native-ts-accountprotection (0.1.6):
+  - react-native-ts-accountprotection (0.1.9):
     - AccountProtection (= 0.0.8006)
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1258,7 +1258,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 32db5e364bcae8fca8cdf8891830636275add0c5
   React-logger: 4136cd22748f4275b04bf82f7b6853ba93b5e0e3
   React-Mapbuffer: ee9b45b26e759a099a3e024df50b25af390ee998
-  react-native-ts-accountprotection: e9561a85d1934ffdc5a790c8dc2f8980956a324d
+  react-native-ts-accountprotection: c8de4b1d1821ddc843b940fe96df4f8104fe9e52
   React-nativeconfig: 1166714a4f7ea57a0df5c2cb44fbc70f98d580f9
   React-NativeModulesApple: d4a50e6739e201716bc90178c143d019c8e09c36
   React-perflogger: 0dd9f1725d55f8264b81efadd373fe1d9cca7dc2

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -72,14 +72,7 @@ export default class App extends React.Component<Props, State> {
   private onAppReady = async (): Promise<void> => {
     // this is for iOS only, Android TSAccountProtectionSDK is initialized from application onCreate.
     if (Platform.OS === 'ios') {
-      const testDisabledFeatures = false;
-
-      await TSAccountProtectionSDKModule.initializeIOS(config.clientId, null,{
-        enableTrackingBehavioralData: !testDisabledFeatures,
-        enableLocationEvents: !testDisabledFeatures,
-        enableTrackingNavigationData: !testDisabledFeatures,
-        enableTrackingStaticData: !testDisabledFeatures
-      });
+      await TSAccountProtectionSDKModule.initializeIOS(config.clientId, null);
     }
 
     const isLogEnabled = true;

--- a/ios/TsAccountprotection.mm
+++ b/ios/TsAccountprotection.mm
@@ -3,7 +3,7 @@
 @interface RCT_EXTERN_MODULE(TsAccountprotection, NSObject)
 
 RCT_EXTERN_METHOD(initializeSDKIOS:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(initializeIOS:(NSString *)clientId baseUrl:(NSString*)baseUrl configurations:(NSDictionary*)configurations withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(initializeIOS:(NSString *)clientId baseUrl:(NSString*)baseUrl withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setUserId:(NSString *)userId withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(triggerAction:(NSString *)action options:(NSDictionary*)options withResolver:(RCTPromiseResolveBlock)resolve

--- a/ios/TsAccountprotection.swift
+++ b/ios/TsAccountprotection.swift
@@ -18,29 +18,14 @@ class TsAccountprotection: NSObject {
             }
         }
     
-    @objc(initializeIOS:baseUrl:configurations:withResolver:withRejecter:)
+    @objc(initializeIOS:baseUrl:withResolver:withRejecter:)
     func initializeIOS(
-      _ clientId: String, baseUrl: String, configurations: [String: Any]?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+      _ clientId: String, baseUrl: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
             runBlockOnMain {
-              var config: AccountProtection.TSInitSDKConfiguration?
-              if let configurations = configurations {
-                let enableTrackingBehavioralData = configurations["enableTrackingBehavioralData"] as? Bool ?? true
-                let enableLocationEvents = configurations["enableLocationEvents"] as? Bool ?? true
-                let enableTrackingNavigationData = configurations["enableTrackingNavigationData"] as? Bool ?? true
-                let enableTrackingStaticData = configurations["enableTrackingStaticData"] as? Bool ?? true
-
-                config = AccountProtection.TSInitSDKConfiguration(
-                  enableTrackingBehavioralData: enableTrackingBehavioralData,
-                  enableLocationEvents: enableLocationEvents,
-                  enableTrackingNavigationData: enableTrackingNavigationData,
-                  enableTrackingStaticData: enableTrackingStaticData
-                )
-              }
-              
                 if baseUrl.isEmpty {
-                    TSAccountProtection.initialize(clientId: clientId, configuration: config)
+                    TSAccountProtection.initialize(clientId: clientId)
                 } else {
-                    TSAccountProtection.initialize(baseUrl: baseUrl, clientId: clientId, configuration: config)
+                    TSAccountProtection.initialize(baseUrl: baseUrl, clientId: clientId)
                 }
                 
                 resolve(true)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ts-accountprotection",
-  "version": "0.1.9",
+  "version": "0.1.8",
   "description": "Wrapper for the Transmit Security Account Protection SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ts-accountprotection",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Wrapper for the Transmit Security Account Protection SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,13 +54,6 @@ export namespace TSAccountProtectionSDK {
     error: string;
   }
 
-  export interface TSConfiguration {
-    enableTrackingBehavioralData?: boolean;
-    enableLocationEvents?: boolean;
-    enableTrackingNavigationData?: boolean;
-    enableTrackingStaticData?: boolean;
-  }
-
   export const enum TSAction {
     login = 'login',
     register = 'register',
@@ -77,7 +70,7 @@ export namespace TSAccountProtectionSDK {
 
 export interface TSAccountProtectionSDKModule {
   initializeSDKIOS: () => Promise<boolean>;
-  initializeIOS: (clientId: string, baseUrl?: string | undefined, configurations?: TSAccountProtectionSDK.TSConfiguration) => Promise<boolean>; 
+  initializeIOS: (clientId: string, baseUrl?: string | undefined) => Promise<boolean>; 
   setUserId: (userId: string) => Promise<boolean>;
   triggerAction: (action: string, options?: TSAccountProtectionSDK.TSActionEventOptions) => Promise<TSAccountProtectionSDK.TSSetActionResponse>;
   clearUser: () => Promise<boolean>;
@@ -90,8 +83,8 @@ class RNAccountProtectionSDK implements TSAccountProtectionSDKModule {
     return TsAccountprotection.initializeSDK();
   }
 
-  initializeIOS(clientId: string, baseUrl?: string | null, configurations?: TSAccountProtectionSDK.TSConfiguration): Promise<boolean> {
-    return TsAccountprotection.initializeIOS(clientId, baseUrl, configurations);
+  initializeIOS(clientId: string, baseUrl?: string | null): Promise<boolean> {
+    return TsAccountprotection.initializeIOS(clientId, baseUrl);
   }
 
   setUserId(userId: string): Promise<boolean> {


### PR DESCRIPTION
## Version 0.1.9

### Breaking Changes (iOS only)
- **Removed TSConfiguration interface**: Simplified SDK initialization by removing configuration options
- **Updated initializeIOS method**: No longer accepts configuration parameters - now only requires `clientId` and optional `baseUrl`
- **Removed tracking configuration options**: Eliminated `enableTrackingBehavioralData`, `enableLocationEvents`, `enableTrackingNavigationData`, and `enableTrackingStaticData` parameters

### API Changes
- **Simplified initialization**: `initializeIOS(clientId: string, baseUrl?: string)` - configuration parameter removed
- **Backward compatibility**: Existing code using `initializeSDKIOS()` continues to work unchanged
